### PR TITLE
mm: mthp support for the PMD level

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -1630,7 +1630,7 @@ config ARCH_FORCE_MAX_ORDER
 	int
 	default "13" if ARM64_64K_PAGES
 	default "11" if ARM64_16K_PAGES
-	default "10"
+	default "15"
 	help
 	  The kernel page allocator limits the size of maximal physically
 	  contiguous allocations. The limit is called MAX_PAGE_ORDER and it

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -565,6 +565,7 @@ struct vm_fault {
 		unsigned long address;		/* Faulting virtual address - masked */
 		unsigned long real_address;	/* Faulting virtual address - unmasked */
 	};
+	unsigned long orders;           /* Allowed orders for folio */
 	enum fault_flag flags;		/* FAULT_FLAG_xxx flags
 					 * XXX: should really be 'const' */
 	pmd_t *pmd;			/* Pointer to pmd entry matching

--- a/include/linux/page_table_check.h
+++ b/include/linux/page_table_check.h
@@ -20,6 +20,8 @@ void __page_table_check_pud_clear(struct mm_struct *mm, pud_t pud);
 void __page_table_check_ptes_set(struct mm_struct *mm, pte_t *ptep, pte_t pte,
 		unsigned int nr);
 void __page_table_check_pmd_set(struct mm_struct *mm, pmd_t *pmdp, pmd_t pmd);
+void __page_table_check_pmds_set(struct mm_struct *mm, pmd_t *pmdp, pmd_t pmd,
+				 unsigned int nr_pmds);
 void __page_table_check_pud_set(struct mm_struct *mm, pud_t *pudp, pud_t pud);
 void __page_table_check_pte_clear_range(struct mm_struct *mm,
 					unsigned long addr,
@@ -83,6 +85,15 @@ static inline void page_table_check_pmd_set(struct mm_struct *mm, pmd_t *pmdp,
 	__page_table_check_pmd_set(mm, pmdp, pmd);
 }
 
+static inline void page_table_check_pmds_set(struct mm_struct *mm, pmd_t *pmdp,
+					     pmd_t pmd, unsigned int nr_pmds)
+{
+	if (static_branch_likely(&page_table_check_disabled))
+		return;
+
+	__page_table_check_pmds_set(mm, pmdp, pmd, nr_pmds);
+}
+
 static inline void page_table_check_pud_set(struct mm_struct *mm, pud_t *pudp,
 					    pud_t pud)
 {
@@ -131,6 +142,11 @@ static inline void page_table_check_ptes_set(struct mm_struct *mm,
 
 static inline void page_table_check_pmd_set(struct mm_struct *mm, pmd_t *pmdp,
 					    pmd_t pmd)
+{
+}
+
+static inline void page_table_check_pmds_set(struct mm_struct *mm, pmd_t *pmdp,
+					    pmd_t pmd, unsigned int nr_pmds)
 {
 }
 

--- a/include/linux/pgtable.h
+++ b/include/linux/pgtable.h
@@ -807,6 +807,12 @@ static inline void update_mmu_tlb(struct vm_area_struct *vma,
 	update_mmu_tlb_range(vma, address, ptep, 1);
 }
 
+#ifndef update_mmu_cache_pmd_range
+#define update_mmu_cache_pmd_range(vma, address, pmd, nr_pmds) \
+	do {                                                   \
+        } while (0)
+#endif
+
 /*
  * Some architectures may be able to avoid expensive synchronization
  * primitives when modifications are made to PTE's which are already

--- a/include/linux/rmap.h
+++ b/include/linux/rmap.h
@@ -225,7 +225,6 @@ static inline void __folio_rmap_sanity_checks(const struct folio *folio,
 		 * when RMAP_LEVEL_PMD is set, we assume that we are creating
 		 * a single "entire" mapping of the folio.
 		 */
-		VM_WARN_ON_FOLIO(folio_nr_pages(folio) != HPAGE_PMD_NR, folio);
 		VM_WARN_ON_FOLIO(nr_pages != HPAGE_PMD_NR, folio);
 		break;
 	default:

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -881,6 +881,20 @@ config READ_ONLY_THP_FOR_FS
 	  support of file THPs will be developed in the next few release
 	  cycles.
 
+config MAX_MULTI_THP_ORDER
+    int "Maximum allowed mTHP order"
+    range 2 ARCH_FORCE_MAX_ORDER
+    default 13
+    help
+      Specify the max order used for mTHP (PTE & PMD-mapped). This value
+      determines mTHP allowable allocation size which will be any
+      order <= MAX_MULTI_THP_ORDER.
+
+      This value can not go beyond ARCH_FORCE_MAX_ORDER. First change
+      the ARCH_FORCE_MAX_ORDER to any allowable values to increase
+      the range. Beware that ARCH_FORCE_MAX_ORDER highly depends on
+      architecture and page_size, So the range of PMD_MTHP_MAX_ORDER
+
 endif # TRANSPARENT_HUGEPAGE
 
 #

--- a/mm/huge_memory.c
+++ b/mm/huge_memory.c
@@ -1149,117 +1149,222 @@ unsigned long thp_get_unmapped_area(struct file *filp, unsigned long addr,
 }
 EXPORT_SYMBOL_GPL(thp_get_unmapped_area);
 
-static struct folio *vma_alloc_anon_folio_pmd(struct vm_area_struct *vma,
-		unsigned long addr)
+static bool pmd_range_none(pmd_t *pmd, int nr_entries)
 {
+	int i;
+
+	for (i = 0; i < nr_entries; i++) {
+		if (!pmd_none(pmdp_get_lockless(pmd + i)))
+			return false;
+	}
+
+	return true;
+}
+
+/**
+ * get_highest_unmapped_orders - Find the highest unmapped order in a bitmap.
+ * @vmf: Pointer to the vm_fault structure describing the fault context.
+ * @orders: Bitmap of candidate orders to evaluate.
+ *
+ * This function identifies the highest order from @orders that is not
+ * mapped in the PMD range of the faulting virtual address in @vmf (No PMD entry
+ * is available).
+ *
+ * Returns:
+ * The updated bitmap starting with the highest unmapped order.
+ */
+static unsigned long get_highest_unmapped_orders(struct vm_fault *vmf,
+						 unsigned long orders)
+{
+	pmd_t *pmdp;
+	unsigned long addr;
+	int order;
+
+	pmdp = pmd_offset(vmf->pud, vmf->address & PUD_MASK);
+	order = highest_order(orders);
+	while (orders) {
+		addr = ALIGN_DOWN(vmf->address, PAGE_SIZE << order);
+		if (pmd_range_none(pmdp + pmd_index(addr),
+				   1 << (order - HPAGE_PMD_ORDER)))
+			break;
+		order = next_order(&orders, order);
+	}
+	return orders;
+}
+
+/**
+ * alloc_anon_folio_pmd - Allocate a non-compound anonymous folio for a PMD-mapped area.
+ * @vmf: Pointer to the vm_fault structure describing the fault context.
+ *
+ * This function determines the maximum order from the @orders bitmap that can span
+ * the virtual memory area (VMA) specified in @vmf->vma. It ensures that the chosen
+ * order does not exceed the not-mapped region in VMA which aligns with given vmf->address.
+ *
+ * Once the appropriate order is determined, the function allocates a folio
+ * (which is inherently a compound page) of the corresponding size. It performs
+ * additional steps including:
+ *  - Charging the memory to the memory control group (memcg) for accounting.
+ *  - Zeroing the allocated folio, unless it has already been initialized during allocation.
+ *
+ * Returns:
+ * A pointer to the allocated folio structure on success, or NULL on failure.
+ */
+static struct folio *alloc_anon_folio_pmd(struct vm_fault *vmf)
+{
+	struct vm_area_struct *vma = vmf->vma;
 	gfp_t gfp = vma_thp_gfp_mask(vma);
-	const int order = HPAGE_PMD_ORDER;
+	unsigned long *orders = &(vmf->orders);
 	struct folio *folio;
+	bool charge_fallback_event;
+	int order;
+	unsigned long addr;
 
-	folio = vma_alloc_folio(gfp, order, vma, addr & HPAGE_PMD_MASK);
+	if (!userfaultfd_armed(vma)) {
+		vmf->ptl = pmd_lock(vma->vm_mm, vmf->pmd);
+		*orders = get_highest_unmapped_orders(vmf, *orders);
+		spin_unlock(vmf->ptl);
+	} else
+		*orders = 1 << HPAGE_PMD_ORDER;
 
-	if (unlikely(!folio)) {
-		count_vm_event(THP_FAULT_FALLBACK);
+	while (*orders) {
+		order = highest_order(*orders);
+		charge_fallback_event = false;
+		addr = ALIGN_DOWN(vmf->address, PAGE_SIZE << order);
+		folio = vma_alloc_folio(gfp, order, vma, addr);
+
+		if (folio) {
+			VM_BUG_ON_FOLIO(!folio_test_large(folio), folio);
+			if (mem_cgroup_charge(folio, vma->vm_mm, gfp)) {
+				folio_put(folio);
+				count_mthp_stat(
+					order,
+					MTHP_STAT_ANON_FAULT_FALLBACK_CHARGE);
+				charge_fallback_event = true;
+				goto try_next_order;
+			}
+			folio_throttle_swaprate(folio, gfp);
+
+			/*
+			 * When a folio is not zeroed during allocation (__GFP_ZERO not used),
+			 * folio_zero_user() is used to make sure that the page corresponding
+			 * to the faulting address will be hot in the cache after zeroing.
+			 */
+			if (!alloc_zeroed())
+				folio_zero_user(folio, addr);
+			/*
+			 * The memory barrier inside __folio_mark_uptodate makes sure that
+			 * folio_zero_user writes become visible before the set_pmd_at()
+			 * write.
+			 */
+			__folio_mark_uptodate(folio);
+			return folio;
+		}
+try_next_order:
 		count_mthp_stat(order, MTHP_STAT_ANON_FAULT_FALLBACK);
-		return NULL;
+		order = next_order(orders, order);
 	}
-
-	VM_BUG_ON_FOLIO(!folio_test_large(folio), folio);
-	if (mem_cgroup_charge(folio, vma->vm_mm, gfp)) {
-		folio_put(folio);
-		count_vm_event(THP_FAULT_FALLBACK);
+	if (charge_fallback_event)
 		count_vm_event(THP_FAULT_FALLBACK_CHARGE);
-		count_mthp_stat(order, MTHP_STAT_ANON_FAULT_FALLBACK);
-		count_mthp_stat(order, MTHP_STAT_ANON_FAULT_FALLBACK_CHARGE);
-		return NULL;
-	}
-	folio_throttle_swaprate(folio, gfp);
-
-       /*
-	* When a folio is not zeroed during allocation (__GFP_ZERO not used)
-	* or user folios require special handling, folio_zero_user() is used to
-	* make sure that the page corresponding to the faulting address will be
-	* hot in the cache after zeroing.
-	*/
-	if (user_alloc_needs_zeroing())
-		folio_zero_user(folio, addr);
-	/*
-	 * The memory barrier inside __folio_mark_uptodate makes sure that
-	 * folio_zero_user writes become visible before the set_pmd_at()
-	 * write.
-	 */
-	__folio_mark_uptodate(folio);
-	return folio;
+	count_vm_event(THP_FAULT_FALLBACK);
+	return NULL;
 }
 
 static void map_anon_folio_pmd(struct folio *folio, pmd_t *pmd,
 		struct vm_area_struct *vma, unsigned long haddr)
 {
 	pmd_t entry;
+	long nr_pages = folio_nr_pages(folio);
+	unsigned long nr_pmds = nr_pages >> HPAGE_PMD_ORDER;
 
 	entry = mk_huge_pmd(&folio->page, vma->vm_page_prot);
 	entry = maybe_pmd_mkwrite(pmd_mkdirty(entry), vma);
 	folio_add_new_anon_rmap(folio, vma, haddr, RMAP_EXCLUSIVE);
 	folio_add_lru_vma(folio, vma);
-	set_pmd_at(vma->vm_mm, haddr, pmd, entry);
-	update_mmu_cache_pmd(vma, haddr, pmd);
-	add_mm_counter(vma->vm_mm, MM_ANONPAGES, HPAGE_PMD_NR);
+	set_pmd_ptes(vma->vm_mm, haddr, pmd, entry, nr_pmds);
+	update_mmu_cache_pmd_range(vma, haddr, pmd, nr_pmds);
+	add_mm_counter(vma->vm_mm, MM_ANONPAGES, nr_pages);
 	count_vm_event(THP_FAULT_ALLOC);
-	count_mthp_stat(HPAGE_PMD_ORDER, MTHP_STAT_ANON_FAULT_ALLOC);
+	count_mthp_stat(folio_order(folio), MTHP_STAT_ANON_FAULT_ALLOC);
 	count_memcg_event_mm(vma->vm_mm, THP_FAULT_ALLOC);
 }
 
 static vm_fault_t __do_huge_pmd_anonymous_page(struct vm_fault *vmf)
 {
-	unsigned long haddr = vmf->address & HPAGE_PMD_MASK;
+	unsigned long haddr;
 	struct vm_area_struct *vma = vmf->vma;
 	struct folio *folio;
-	pgtable_t pgtable;
+	pgtable_t *pgtable_array;
 	vm_fault_t ret = 0;
+	int index;
+	unsigned long nr_pmds;
+	int order;
 
-	folio = vma_alloc_anon_folio_pmd(vma, vmf->address);
+	folio = alloc_anon_folio_pmd(vmf);
 	if (unlikely(!folio))
 		return VM_FAULT_FALLBACK;
 
-	pgtable = pte_alloc_one(vma->vm_mm);
-	if (unlikely(!pgtable)) {
+	order = folio_order(folio);
+	nr_pmds = 1 << (order - HPAGE_PMD_ORDER);
+	haddr = ALIGN_DOWN(vmf->address, PAGE_SIZE << order);
+
+	pgtable_array = kcalloc(nr_pmds, sizeof(pgtable_t), GFP_KERNEL);
+	if (unlikely(!pgtable_array)) {
 		ret = VM_FAULT_OOM;
 		goto release;
 	}
 
-	vmf->ptl = pmd_lock(vma->vm_mm, vmf->pmd);
-	if (unlikely(!pmd_none(*vmf->pmd))) {
-		goto unlock_release;
-	} else {
-		ret = check_stable_address_space(vma->vm_mm);
-		if (ret)
-			goto unlock_release;
-
-		/* Deliver the page fault to userland */
-		if (userfaultfd_missing(vma)) {
-			spin_unlock(vmf->ptl);
-			folio_put(folio);
-			pte_free(vma->vm_mm, pgtable);
-			ret = handle_userfault(vmf, VM_UFFD_MISSING);
-			VM_BUG_ON(ret & VM_FAULT_FALLBACK);
-			return ret;
+	for (index = 0; index < nr_pmds; ++index) {
+		pgtable_array[index] = pte_alloc_one(vma->vm_mm);
+		if (unlikely(!pgtable_array[index])) {
+			ret = VM_FAULT_OOM;
+			goto release;
 		}
-		pgtable_trans_huge_deposit(vma->vm_mm, vmf->pmd, pgtable);
-		map_anon_folio_pmd(folio, vmf->pmd, vma, haddr);
-		mm_inc_nr_ptes(vma->vm_mm);
-		deferred_split_folio(folio, false);
-		spin_unlock(vmf->ptl);
 	}
 
+	vmf->ptl = pmd_lock(vma->vm_mm, vmf->pmd);
+	if (unlikely(!pmd_none(*vmf->pmd)))
+		goto unlock_release;
+
+	if (vmf->orders != get_highest_unmapped_orders(vmf, vmf->orders)) {
+		ret = VM_FAULT_RETRY;
+		goto unlock_release;
+	}
+
+	vmf->pmd = pmd_offset(vmf->pud, haddr);
+	ret = check_stable_address_space(vma->vm_mm);
+	if (ret)
+		goto unlock_release;
+
+	/* Deliver the page fault to userland */
+	if (userfaultfd_missing(vma)) {
+		spin_unlock(vmf->ptl);
+		while (--index >= 0)
+			pte_free(vma->vm_mm, pgtable_array[index]);
+		kfree(pgtable_array);
+		folio_put(folio);
+		ret = handle_userfault(vmf, VM_UFFD_MISSING);
+		VM_BUG_ON(ret & VM_FAULT_FALLBACK);
+		return ret;
+	}
+	for (index = 0; index < nr_pmds; index++) {
+		pgtable_trans_huge_deposit(vma->vm_mm, vmf->pmd,
+					   pgtable_array[index]);
+		mm_inc_nr_ptes(vma->vm_mm);
+	}
+	folio_ref_add(folio, nr_pmds - 1);
+	map_anon_folio_pmd(folio, vmf->pmd, vma, haddr);
+	deferred_split_folio(folio, false);
+	spin_unlock(vmf->ptl);
+	kfree(pgtable_array);
 	return 0;
 unlock_release:
 	spin_unlock(vmf->ptl);
 release:
-	if (pgtable)
-		pte_free(vma->vm_mm, pgtable);
+	while (--index >= 0)
+		pte_free(vma->vm_mm, pgtable_array[index]);
+	kfree(pgtable_array);
 	folio_put(folio);
 	return ret;
-
 }
 
 /*
@@ -1318,7 +1423,8 @@ vm_fault_t do_huge_pmd_anonymous_page(struct vm_fault *vmf)
 	unsigned long haddr = vmf->address & HPAGE_PMD_MASK;
 	vm_fault_t ret;
 
-	if (!thp_vma_suitable_order(vma, haddr, PMD_ORDER))
+	vmf->orders = thp_vma_suitable_orders(vma, haddr, vmf->orders);
+	if (!vmf->orders)
 		return VM_FAULT_FALLBACK;
 	ret = vmf_anon_prepare(vmf);
 	if (ret)
@@ -1806,7 +1912,9 @@ static vm_fault_t do_huge_zero_wp_pmd(struct vm_fault *vmf)
 	struct folio *folio;
 	vm_fault_t ret = 0;
 
-	folio = vma_alloc_anon_folio_pmd(vma, vmf->address);
+	vmf->orders = 1 << HPAGE_PMD_ORDER;
+	folio = alloc_anon_folio_pmd(vmf);
+
 	if (unlikely(!folio))
 		return VM_FAULT_FALLBACK;
 

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -5662,14 +5662,14 @@ out_map:
 static inline vm_fault_t try_create_huge_pmd(struct vm_fault *vmf)
 {
 	struct vm_area_struct *vma = vmf->vma;
-	unsigned long orders = thp_vma_allowable_orders(vma, vma->vm_flags,
+	vmf->orders = thp_vma_allowable_orders(vma, vma->vm_flags,
 						TVA_IN_PF | TVA_ENFORCE_SYSFS,
-						PMD_ORDER);
-	if (orders & PMD_ORDER)
+						THP_ORDER_PMD_ANON);
+	if (!vmf->orders)
 		return VM_FAULT_FALLBACK;
 	if (vma_is_anonymous(vma))
 		return do_huge_pmd_anonymous_page(vmf);
-	if (vma->vm_ops->huge_fault)
+	if ((vmf->orders & PMD_ORDER) && vma->vm_ops->huge_fault)
 		return vma->vm_ops->huge_fault(vmf, PMD_ORDER);
 	return VM_FAULT_FALLBACK;
 }

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -1728,7 +1728,7 @@ static inline unsigned long zap_pmd_range(struct mmu_gather *tlb,
 	do {
 		next = pmd_addr_end(addr, end);
 		if (is_swap_pmd(*pmd) || pmd_trans_huge(*pmd) || pmd_devmap(*pmd)) {
-			if (next - addr != HPAGE_PMD_SIZE)
+			if (next - addr < HPAGE_PMD_SIZE)
 				__split_huge_pmd(vma, pmd, addr, false, NULL);
 			else if (zap_huge_pmd(tlb, vma, pmd, addr)) {
 				addr = next;

--- a/mm/mempolicy.c
+++ b/mm/mempolicy.c
@@ -2235,7 +2235,8 @@ struct page *alloc_pages_mpol_noprof(gfp_t gfp, unsigned int order,
 
 	if (IS_ENABLED(CONFIG_TRANSPARENT_HUGEPAGE) &&
 	    /* filter "hugepage" allocation, unless from alloc_pages() */
-	    order == HPAGE_PMD_ORDER && ilx != NO_INTERLEAVE_INDEX) {
+	    (order >= HPAGE_PMD_ORDER && order < HPAGE_PUD_ORDER) &&
+	    ilx != NO_INTERLEAVE_INDEX) {
 		/*
 		 * For hugepage allocation and non-interleave policy which
 		 * allows the current node (or other explicitly preferred

--- a/mm/page_table_check.c
+++ b/mm/page_table_check.c
@@ -234,22 +234,31 @@ static inline void page_table_check_pmd_flags(pmd_t pmd)
 		WARN_ON_ONCE(swap_cached_writable(pmd_to_swp_entry(pmd)));
 }
 
-void __page_table_check_pmd_set(struct mm_struct *mm, pmd_t *pmdp, pmd_t pmd)
+void __page_table_check_pmds_set(struct mm_struct *mm, pmd_t *pmdp, pmd_t pmd,
+				 unsigned int nr_pmds)
 {
+	int i;
 	if (&init_mm == mm)
 		return;
 
 	page_table_check_pmd_flags(pmd);
 
-	__page_table_check_pmd_clear(mm, *pmdp);
+	for (i = 0; i < nr_pmds; i++)
+		__page_table_check_pmd_clear(mm, pmdp_get(pmdp + i));
 	if (pmd_user_accessible_page(pmd)) {
-		page_table_check_set(pmd_pfn(pmd), PMD_SIZE >> PAGE_SHIFT,
+		page_table_check_set(pmd_pfn(pmd), (nr_pmds * PMD_SIZE) >> PAGE_SHIFT,
 				     pmd_write(pmd));
 	}
 }
+
+void __page_table_check_pmd_set(struct mm_struct *mm, pmd_t *pmdp, pmd_t pmd)
+{
+	__page_table_check_pmds_set(mm, pmdp, pmd, 1);
+}
 EXPORT_SYMBOL(__page_table_check_pmd_set);
 
-void __page_table_check_pud_set(struct mm_struct *mm, pud_t *pudp, pud_t pud)
+void __page_table_check_pud_set(struct mm_struct *mm, pud_t *pudp,
+					pud_t pud)
 {
 	if (&init_mm == mm)
 		return;

--- a/mm/rmap.c
+++ b/mm/rmap.c
@@ -1344,9 +1344,7 @@ static __always_inline void __folio_add_anon_rmap(struct folio *folio,
 		struct page *cur_page = page + i;
 
 		/* While PTE-mapping a THP we have a PMD and a PTE mapping. */
-		VM_WARN_ON_FOLIO((atomic_read(&cur_page->_mapcount) > 0 ||
-				  (folio_test_large(folio) &&
-				   folio_entire_mapcount(folio) > 1)) &&
+		VM_WARN_ON_FOLIO((atomic_read(&cur_page->_mapcount) > 0) &&
 				 PageAnonExclusive(cur_page), folio);
 	}
 
@@ -1465,9 +1463,9 @@ void folio_add_new_anon_rmap(struct folio *folio, struct vm_area_struct *vma,
 		atomic_set(&folio->_nr_pages_mapped, nr);
 	} else {
 		/* increment count (starts at -1) */
-		atomic_set(&folio->_entire_mapcount, 0);
+		atomic_set(&folio->_entire_mapcount, (nr >> HPAGE_PMD_ORDER) - 1);
 		/* increment count (starts at -1) */
-		atomic_set(&folio->_large_mapcount, 0);
+		atomic_set(&folio->_large_mapcount, (nr >> HPAGE_PMD_ORDER) - 1);
 		atomic_set(&folio->_nr_pages_mapped, ENTIRELY_MAPPED);
 		if (exclusive)
 			SetPageAnonExclusive(&folio->page);


### PR DESCRIPTION
From b324f55787ba48abfda6e9707613bf9b79c872e5 Mon Sep 17 00:00:00 2001
From: Tarun Sahu <jjs.tarun@gmail.com>
Date: Sun, 15 Dec 2024 21:16:13 +0000
Subject: [RFC PATCH 00/11] mm: thp: mTHP support for PMD level

This patch introduces support for Transparent Huge Pages (THP) of sizes
greater than PMD-order in the Linux kernel. Previously, the multi-size
THP feature only allowed THPs up to PMD-order to be mapped at the PTE
level [1]. This patch extends the support to allow higher order THPs to
also be allocated at page fault request and can be mapped with
multiple PMDs. Currently, The support is only added for anonymous page
mapping.

THP feature is crucial for improving the performance of memory-intensive
applications. By reducing the number of page table entries (PTEs), it
improves Translation Lookaside Buffer (TLB) coverage and significantly
reduces TLB misses and page table walks. With the current multi-size THP
implementation, users can benefit from a granularity smaller than the
default HPAGE_PMD_ORDER and greater than PAGE_SIZE
(e.g.,fragmented memory, lru contention, kernel per page management
overhead). However, there remains an opportunity to extend support to
larger sizes to be able to use these benefits for large memory allocation
as well like for VM or in-memory db etc.

Applications dealing with datasets that require more contiguous memory
(much greater than PMD size) and applications benefiting from optimized
paging and TLB hit rates can see significant performance improvements
with multiple THPs each of PMD size. But for large memory allocation,
each PMD allocation will trigger the page fault which is a costly
opertaion as it includes allocation, mapping and various checks. These
all operation will be performed for each THP. We can get greater benefit
by allowing the allocation of large folio at single fault time which will
be mTHP of order > PMD_ORDER. This will reduce the number of page faults
and per-page operations (e.g. ref counting, rmap management, lru list
management)

Some architectures have support of HW TLB compression techniques like
"the contiguous bit" and HPA on ARM64. The same support is/can also/be
available for PMD level entries which will also greatly enhance
performance by less TLB misses and less page table walks.

Approach
========

By maintaining the full backward compatibility with PMD_ORDER THP and
smaller mTHPs, this patchset just overlays on top of previous mTHP patch
series [1]. This patch has taken the similar approach as of [1] where the
sysfs functionality [2][3] is extended for user to enable/stats mTHP >=
PMD_ORDER. Changed the vma_alloc_anon_folio_pmd function to
alloc_anon_folio_pmd to maintain the consistency with PTEs mTHPs, This
function allocates the folio of any size in multiple of PMD_SIZE. A new
argument is added into vm_fault struct which is used in pmd thp fault
path to keep track of allowable orders at each stage till it is consumed
by alloc_anon_folio_pmd. Now that multiple PMD are needed to be mapped,
map_anon_folio_pmd is enhanced to update multiple PMD_PTEs at once.

There was one more thought, to give user flexibity of kernel
command line to set max order allocation, but this will restrict
the user to understand the limitation with ARCH_FORCE_MAX_ORDER.
Having a menuconfig option, User can observe that config value
can not be set beyond ARCH_FORCE_MAX_ORDER limit.

Currently, I have not touched GFP flags for PMD-mTHP allocation. The
gfp flags returned by vma_thp_gfp_mask will also have _GFP_DIRECT_RECLAIM
in some cases which will try to allocate the memory via slowpath (fault
time compaction & direct reclaim) if folio is not found normally. This
will be very constly operation for each page-fault and consecutive
page-fault. This can be improved by avoiding the slow path allocation in
alloc_anon_folio_pmd till the folio is not found for
order > HPAGE_PMD_ORDER and once orders mask has only PMD_ORDER, the
_GFP_DIRECT_RECLAIM flag can be again set to approach slow-path. This
apparoch will try to allocate the folio smaller order, instead of
triggering the slowe path for each order > HPAGE_PMD_ORDER

I am quite new in other mm subsystem, I would have missed the
dependecies of this change, I would like to request the community
to help me find out the affected areas while I will also be
polishing my skills in other areas as well. :)

Prerequisites / Afterwork
=========================
Here comes the pain points:

I have categorized the following required work in three categories
A. Works But will require thorough review (C-A)
B. Doesn't work but doesn't harm as well (C-B)
C. Doesn't work but harm the system as well (C-C)
with two types
"prereq" AND "afterwork"

1. mapcount/split_huge_page on unmap. Likely workaround patch [01/11]
(C-A) (prereq)
	As much as I could understand about mapcount philosphy,
	_entire_mapcount counts the number of times a folio is mapped as
	single entity. But incase of mTHP multi PMD order, this should be
	-1. As it is not mapped as single entity. But setting -1 will create
	warnings, As unampping the folio partially will cause one of the PMD
	entries to split and will reduce its folio _entire_mapcount which it
	assumes to be set as it is PMD mapped. and once reduced the value will
	go down to -2 and which will fail in a check and raise VM_WARN_ON.
	This unmap codepath will need some work to handle mapcounts properly.
	There is only concept of ENTIRELY_MAPPED which I didn't get chance to
	look at it and will require changes as well.

	split huge page is core of partial unmap. mTHP itself an compound page,
	whose first page will be a head page. If we unmap the first PMD THP,
	How other PMD THP tail pages be able to refer to that page? there will
	be some mapcount mechanism that will be checked if the folio is still
	mapped though partially split, the folio still can not lose compound
	page property. Testing partial unmapping works as expected. But I didn't
	get a chance to thoroughly go through the code, This part will
	also require proper testing and review.

2. mTHP allocation at write Fault after read fault
(C-B) (afterwork)
	Linux allocates huge zero page on read fault which will be of order
	HPAGE_PMD_ORDER. When write-fault occurs, on the same memory, it will
	only allocate the THP of order HPAGE_PMD_ORDER, it is because the
	pgtable list which is used for splitting and used as pte table, is
	only one allocated. This must be allocated to allowable order to
	enable PMD-order mTHP.

3. Arch specific call
(C-B) (afterwork)
	This patch series added few call in arch specific code, where PMD_ORDER
	is used extensively instead of HPAGE_PMD_ORDER. which is kind of worry
	that might not be same for each architecture. This check will need to
	be taken care of and tested on each architecture.

4. Migration, Numa balancing and compaction
(Unknown)
	I tried testing it, but didn't get succeed. syscall move_pages accepts
	argument in number of PAGE_SIZE page aligned pages. while my allocation
	is in THP size. I tried chekcing migrate_pages api but every one of them
	is PAGE_SIZE dependent.

	I looked into the code which does copy of folio_nr_pages from src to dst.
	but there are more to it. But I very new to migration and numa balancing,
	I can not make correct decision about this feature.

	If any of the above requires splitting of THP, that will categorized as
	(C-B), but more thorough review will be required.

5. Reclaim / Swapping
(C-B)
	I haven't tested this, Also I don't have understanding in this area.
	But Here I am giving my analogy anyway, swapping the complete folio
	of size which is multiple of PMD can not be done in one go. because
	it will at least require updating the each PMD_PTEs swap bits to make
	it swap_entry. for what the code won't be there. Also if it gets
	swapped by splitting, the split mTHP code as mentioned abvoe requires
	some working.

6. mlock
(C-B) (prerequisite)
	The support for mTHP was added, but everywhere it was assumed that
	mTHP is not equal to or more than size PMD_ORDER. The offset and
	pte update is of order of PAGE_SIZE. IIUC, this will require change
	for PMD_ORDER and > PMD_ORDER mTHPs.

7. split huge page/deferred split
(C-B) (prerequisite)
	As mentioned above, split code path needs to be reviewed.

8. shared vs exclusive mappings
(C-B)
	I have run tests [4] for exclusive mapping, haven't tested for shared
	mapping. Likely this won't have any issues. Still I will put in C-B
	to have it tested and reviewed.


Mostly the code path, where folio (mapped as multiple PMDs) distinguishes
its identity saperate from normal folio (mapped as single PMD or PTE or
PTEs), there we will have to do code review to check its working. like,
above mentioned, swapping/migration etc requires the changes to the
mapping and update the mapcount flags. Such places in system will be
affected mostly. Which we will have to add to the above list If I have
missed any in above.

Testing
=======

I have run a custom script[4] to observe the stats at mapping, fault
and unmapping time. Also verified the values, that are written to
the allocated pages, which ensures that page table entries are correctly
populated. I have used qemu qemu-system-aarch64 for arm64 system which
had the following specs
Memory: 60G distributed equally between 3-NUMA nodes.
CPUs: SMP 8
Debian Image: [5]

[1] https://lore.kernel.org/all/20231207161211.2374093-1-ryan.roberts@arm.com/#r
[2] https://lore.kernel.org/all/20231207161211.2374093-4-ryan.roberts@arm.com/
[3] https://lore.kernel.org/linux-mm/6d89fdc9-ef55-d44e-bf12-fafff318aef8@redhat.com/
[4] https://github.com/jj-tarun/mthp_scripts/blob/main/map_unamp.c
[5] https://cdn.kernel.org/pub/linux/kernel/people/will/docs/qemu/qemu-arm64-howto.html

Tarun Sahu (11):
  mm: Remove few WARN_ON and update folio_add_new_anon_rmap for PMD mTHP
  mm/memory: refactor hugepage allocation function create_huge_pmd
  mm: more refined condition for HUGE_PMD_CHECK in zap_pmd_range
  mm/pgtable: Add support to check multiple consecutive pmds
  mm/pgtable: Add support for set multiple consecutive pmd ptes
  Add support for arch specific update_mmu_cache_pmd for range of pmds
  Allow page alloc mpol api to allocate hugepage larger than PMD_ORDER
  Introduce the config option to select max mTHP order
  arch/arm64: increase the default value of FORCE_MAX_ORDER for 4K page
  Introduce the macro to get populate user given max mTHP order
  mm: extend multi-size THP support for order > PMD_ORDER

 arch/arc/include/asm/hugepage.h              |   7 +-
 arch/arc/mm/tlb.c                            |  16 +-
 arch/arm/include/asm/tlbflush.h              |   6 +-
 arch/arm64/Kconfig                           |   2 +-
 arch/arm64/include/asm/pgtable.h             |  28 ++-
 arch/loongarch/include/asm/pgtable.h         |  20 +-
 arch/mips/include/asm/pgtable.h              |  21 +-
 arch/powerpc/include/asm/book3s/64/pgtable.h |   8 +-
 arch/riscv/include/asm/pgtable.h             |  28 ++-
 arch/s390/include/asm/pgtable.h              |   6 +-
 arch/sparc/include/asm/pgtable_64.h          |   6 +-
 arch/sparc/mm/init_64.c                      |  42 ++--
 arch/x86/include/asm/pgtable.h               |   7 +-
 include/linux/huge_mm.h                      |  20 +-
 include/linux/page_table_check.h             |  16 ++
 include/linux/pgtable.h                      |  38 +++
 include/linux/rmap.h                         |   1 -
 mm/Kconfig                                   |  14 ++
 mm/huge_memory.c                             | 245 ++++++++++++++-----
 mm/memory.c                                  |  19 +-
 mm/mempolicy.c                               |   3 +-
 mm/page_table_check.c                        |  17 +-
 mm/rmap.c                                    |   8 +-
 23 files changed, 422 insertions(+), 156 deletions(-)

--
2.47.1.613.gc27f4b7a9f